### PR TITLE
Update source path for package generation on peer

### DIFF
--- a/doc_source/get-started-chaincode.md
+++ b/doc_source/get-started-chaincode.md
@@ -9,7 +9,7 @@ Run the following command to install example chaincode on the peer node:
 ```
 docker exec cli peer chaincode install \
 -n mycc -v v0 \
--p github.com/chaincode_example02/go
+-p /opt/gopath/src/github.com/chaincode_example02/go
 ```
 
 ## Step 7\.2: Instantiate Chaincode<a name="get-started-create-instantiate-chaincode"></a>


### PR DESCRIPTION
*Issue #, if available:*
The command 
`
docker exec cli peer lifecycle chaincode package ./abstore.tar.gz \
--path fabric-samples/chaincode/abstore/go/ \
--label abstore_1
`
returns 
Error: error getting chaincode bytes: 'go list' failed with: package fabric-samples/chaincode/abstore/go is not in GOROOT (/usr/local/go/src/fabric-samples/chaincode/abstore/go): exit status 1

Expected: success
*Description of changes:*
Using absolute path fix the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
